### PR TITLE
feat: add voice alphabet demo with audio support and new subject option

### DIFF
--- a/app/board/demo/[id]/page.jsx
+++ b/app/board/demo/[id]/page.jsx
@@ -1,9 +1,13 @@
 'use client';
+
+import { use } from 'react';
 import Board from '../../../../components/board';
 import DefaultErrorPage from 'next/error';
 import { demoIds } from '../../../../lib/questions';
 
-export default function Exercise({ params: { id: demoId }}) {
+export default function Exercise(props) {
+
+    const { id: demoId } = use(props.params);
 
     let notes, subject;
 
@@ -27,8 +31,10 @@ export default function Exercise({ params: { id: demoId }}) {
             subject = 'Deskové hry';
             break;
         case demoIds.CHESS_1:
-
             subject = 'Šachy';
+            break;
+        case demoIds.VOICE_ALPHABET_CZ_1:
+            subject = 'Česká abeceda';
             break;
         case demoIds.LARGER_1:
             subject = 'Matematika';

--- a/components/demo.js
+++ b/components/demo.js
@@ -50,6 +50,12 @@ export default function Demo() {
                             </div>
                             <div className='input-group'>
                                 <div className='input-group-text btn-sm' style={{ maxWidth: '100px', minWidth: '100px' }}>
+                                    Písmena
+                                </div>
+                                <Link legacyBehavior href='/board/demo/voice-alphabet-cz-1' as='/board/demo/voice-alphabet-cz-1'><a role='button' title='Písmena' className='btn btn-outline-primary btn-sm'>ABCD</a></Link>
+                            </div>
+                            <div className='input-group'>
+                                <div className='input-group-text btn-sm' style={{ maxWidth: '100px', minWidth: '100px' }}>
                                     TV 📺
                                     <span className='ps-1 tv'></span>
                                 </div>

--- a/components/question.jsx
+++ b/components/question.jsx
@@ -54,6 +54,11 @@ export default function Question({ demoId, subject }) {
         setResult();
         setDisabledOptionsOK([]);
         setDisabledOptionsKO([]);
+
+        if (demoId === demoIds.VOICE_ALPHABET_CZ_1) {
+            // if there is an <audio> element, play it again
+            document.querySelector('audio')?.play();
+        }
     };
 
     const handleAnswerClick = async(evt, clickedOptionIndex) => {

--- a/components/question.jsx
+++ b/components/question.jsx
@@ -137,7 +137,12 @@ export default function Question({ demoId, subject }) {
                 } else {
                     // It is a react component. Pass it another props.
                     // Clone doesn't do re-render.
-                    const newTextComponent = getNewTextComponent(demoId, question.textComponentProps, { result });
+                    let textComponentProps = question.textComponentProps;
+                    if (demoId === demoIds.VOICE_ALPHABET_CZ_1) {
+                        // Prevent playing audio again.
+                        textComponentProps = null;
+                    }
+                    const newTextComponent = getNewTextComponent(demoId, textComponentProps, { result });
                     setQuestion({ ...question, textComponent: newTextComponent, text: undefined });
                 }
             }

--- a/lib/questions.js
+++ b/lib/questions.js
@@ -35,7 +35,8 @@ export function getNewTextComponent(demoId, textComponentProps, newProps) {
             return <PatternText question={textComponentProps} {...newProps} />;
         }
         case demoIds.VOICE_ALPHABET_CZ_1: {
-            return <audio controls autoPlay src={textComponentProps.audioUrl} />;
+            // textComponentProps is null when the question is completed to prevent from playing the audio again.
+            return <audio controls autoPlay src={textComponentProps?.audioUrl} />;
         }
         default:
             return;

--- a/lib/questions.js
+++ b/lib/questions.js
@@ -16,6 +16,7 @@ export const demoIds = {
     DICE_KARAK_1: 'dice-karak-1',
     /** Allowed moves for a single piece. */
     CHESS_1: 'chess-1',
+    VOICE_ALPHABET_CZ_1: 'voice-alphabet-cz-1',
     LARGER_1: 'larger-1',
     LARGER_2: 'larger-2',
     LARGER_3: 'larger-3',
@@ -458,6 +459,60 @@ export function generateDemoQuestion({ demoId, subject }) {
 
                 // Emoji explosion on correct answer when the move animation is finished.
                 emojiDelay = 2000;
+
+                break;
+            }
+
+            case demoIds.VOICE_ALPHABET_CZ_1: {
+
+                const audioUrls = {
+                    A: 'https://utfs.io/f/BydazjEOdFUin9um3aoay5bQFmYj4CcJri9P8vUL13SdHgxo',
+                    B: 'https://utfs.io/f/BydazjEOdFUiIKxohVkXwIrlumOVnxPSf28e1Wdzh4C0D7Yi',
+                    C: 'https://utfs.io/f/BydazjEOdFUiw1dO5GyjmWYRp6FDeykLP4ufnjrdUacExJ3A',
+                    D: 'https://utfs.io/f/BydazjEOdFUiTn1zr7IC7dVXnK1lxLBqQREuYrHD504J2U8y',
+                    E: 'https://utfs.io/f/BydazjEOdFUiZnH5LPWkomFgfEBQWh2lj5csPA0bUa7IxV1M',
+                    F: 'https://utfs.io/f/BydazjEOdFUiUEkoCNhMJtuX9pWcownVBGCe065Zyi2Fm7Aa',
+                    G: 'https://utfs.io/f/BydazjEOdFUiqgq5xAyzSCoViD09LZPlXy1g75pmQGHEUr4N',
+                    H: 'https://utfs.io/f/BydazjEOdFUiTO84vKIC7dVXnK1lxLBqQREuYrHD504J2U8y',
+                    I: 'https://utfs.io/f/BydazjEOdFUikoIYa55u8iL9e0EZh4vz3BjSNYQ1qdU7GAmD',
+                    J: 'https://utfs.io/f/BydazjEOdFUiJJMEgFGYXvFn82fRlCDPx41hBHwbGO9QWgUM',
+                    K: 'https://utfs.io/f/BydazjEOdFUiDr0GWge80AsrXvaUp1wlObQfcMCFnduZz62o',
+                    L: 'https://utfs.io/f/BydazjEOdFUiCKuJc2MQ2fx5h7ITtAM8qSN0Lri6RV9uczPw',
+                    M: 'https://utfs.io/f/BydazjEOdFUiKZu4FyLSbmHzXeIo9ta8qGKAuUL0iTlYdQ1V',
+                    N: 'https://utfs.io/f/BydazjEOdFUi4BtbKTsPya8Vo0DO9Q5rswJGvtIk3BbT6lH7',
+                    O: 'https://utfs.io/f/BydazjEOdFUi4wni2wBsPya8Vo0DO9Q5rswJGvtIk3BbT6lH',
+                    P: 'https://utfs.io/f/BydazjEOdFUi4wuKtpzsPya8Vo0DO9Q5rswJGvtIk3BbT6lH',
+                    Q: 'https://utfs.io/f/BydazjEOdFUidkQcRz4WmKVeWlQM3ifb5yOPTvUC7A8aXqI1',
+                    R: 'https://utfs.io/f/BydazjEOdFUiKW3hteLSbmHzXeIo9ta8qGKAuUL0iTlYdQ1V',
+                    S: 'https://utfs.io/f/BydazjEOdFUi8Uw1gYNOg4WnZypHlLOdvEkiF6M23mAaJq7t',
+                    T: 'https://utfs.io/f/BydazjEOdFUiXw9cqzgUhPVuOBcldympkStwfzMaEQKiq8Ng',
+                    U: 'https://utfs.io/f/BydazjEOdFUiznuf41FIqCoglDJF6krcPxN27GpAUW3OhMfb',
+                    V: 'https://utfs.io/f/BydazjEOdFUiJTeK4EXGYXvFn82fRlCDPx41hBHwbGO9QWgU',
+                    W: 'https://utfs.io/f/BydazjEOdFUiZ7jKWWkomFgfEBQWh2lj5csPA0bUa7IxV1Me',
+                    X: 'https://utfs.io/f/BydazjEOdFUiOLs0ojam1w53ESg7U4tYjyRrZQkNp0MXJWTs',
+                    Y: 'https://utfs.io/f/BydazjEOdFUi0ZrJBAFdjvNbdaLyz8SMeuistE2G7nBk65oX',
+                    Z: 'https://utfs.io/f/BydazjEOdFUixtxJtaDndU8kTq67QJglCSVhRDXozHO21Z4e',
+                };
+
+                const letters = Object.keys(audioUrls);
+                const correctLetter = _.sample(letters);
+                const audioUrl = audioUrls[correctLetter];
+
+                options = [{ id: correctLetter, value: correctLetter }].concat(
+                    letters
+                        .filter(letter => letter !== correctLetter)
+                        .map((letter) => ({ id: letter, value: letter }))
+                ).slice(0, 3);
+                // Only 3 options, one of them is the correct letter.
+                options = _.shuffle(options);
+
+                textComponent = <div>
+                    <audio controls autoPlay src={audioUrl} />
+                </div>;
+
+                solution = correctLetter;
+
+                break;
             }
         }
     }

--- a/lib/questions.js
+++ b/lib/questions.js
@@ -34,6 +34,9 @@ export function getNewTextComponent(demoId, textComponentProps, newProps) {
         case demoIds.PATTERNS_1: {
             return <PatternText question={textComponentProps} {...newProps} />;
         }
+        case demoIds.VOICE_ALPHABET_CZ_1: {
+            return <audio controls autoPlay src={textComponentProps.audioUrl} />;
+        }
         default:
             return;
     }
@@ -509,6 +512,7 @@ export function generateDemoQuestion({ demoId, subject }) {
                 textComponent = <div>
                     <audio controls autoPlay src={audioUrl} />
                 </div>;
+                textComponentProps = { audioUrl };
 
                 solution = correctLetter;
 


### PR DESCRIPTION
This pull request introduces a new demo feature for the Czech alphabet within the application. The changes include adding new identifiers, updating the UI to include the new demo, and implementing the logic for generating demo questions related to the Czech alphabet.

Key changes include:

### Feature Addition:
* Added a new demo ID for the Czech alphabet (`VOICE_ALPHABET_CZ_1`) in `lib/questions.js`.
* Implemented logic to generate demo questions for the Czech alphabet, including audio URLs for each letter and the correct answer selection process in `lib/questions.js`.

### UI Updates:
* Updated the `Exercise` component to handle the new demo ID and display the appropriate subject in `app/board/demo/[id]/page.jsx`. ([app/board/demo/[id]/page.jsxL30-R38](diffhunk://#diff-c0a2cda27488ad22fad8f5e5989c41ca4fb991935cf903f71a50fc548e019ba8L30-R38))
* Added a new button for the Czech alphabet demo in the `Demo` component's UI in `components/demo.js`.

### Code Refactoring:
* Modified the `Exercise` component to use the `use` hook from React for extracting parameters in `app/board/demo/[id]/page.jsx`. ([app/board/demo/[id]/page.jsxR2-R10](diffhunk://#diff-c0a2cda27488ad22fad8f5e5989c41ca4fb991935cf903f71a50fc548e019ba8R2-R10))